### PR TITLE
Update README.md for control extensions

### DIFF
--- a/docs/control/extensions/README.md
+++ b/docs/control/extensions/README.md
@@ -57,7 +57,7 @@ the number relates to how often the record time or shooting mode is displayed (v
 - **HSTP=x,z,size** - Used with HIST=1, this sets the size (40-100) and position (x,y as 1-100) of the histogram. 
 A negative x-value will place the histograme on the front screen. e.g. oMHSTP=1,83,67 or oMHSTP=-3,55,87.
 <br>![HSTPfront.jpg](HSTPfront.jpg)
-- **LEVL=size** - Add a spirit level to the rear LCD, where the size can be 1-9. e.g. oMLEVL=6. Color was added for HERO12.
+- **LEVL=size** - Add a spirit level to the rear LCD, where the size can be 1-9. e.g. oMLEVL=6. Color for the spirit level line was added for HERO11 and HERO12. LEVL has three colors with no controls. White - nothing is level. Yellow - the horizon is level. Green - the horizon and pitch is level
 <br>![LEVLnew.jpg](LEVLnew.jpg)
 - **LOGB=logbase,offset** - Super experimental, alter the log encoding for more dynamic range, or for a closer match with other camera's log curves. 
 i.e design your own flat profile. Ideal for use with 10-bit, and the existing flat color setting.  


### PR DESCRIPTION
Added more information about the LEVL extension. LEVL has three colors with no controls. White - nothing is level
Yellow - the horizon is level
Green - the horizon and pitch is level
Updated to show it applies for Hero11 and Hero12